### PR TITLE
Fix ELLA timesteps

### DIFF
--- a/ella.py
+++ b/ella.py
@@ -18,34 +18,6 @@ for i, f_path in enumerate([folder_names_and_paths["t5_model"], folder_names_and
     if not os.path.exists(f_path):
         os.makedirs(f_path, exist_ok=True)
 
-# Borrowed from https://github.com/BlenderNeko/ComfyUI_Noise Until patch update.
-class GetSigma:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {"required": {
-            "model": ("MODEL",),
-            "sampler_name": (comfy.samplers.KSampler.SAMPLERS, ),
-            "scheduler": (comfy.samplers.KSampler.SCHEDULERS, ),
-            "steps": ("INT", {"default": 10000, "min": 0, "max": 10000}),
-            "start_at_step": ("INT", {"default": 0, "min": 0, "max": 10000}),
-            "end_at_step": ("INT", {"default": 10000, "min": 1, "max": 10000}),
-            }}
-    
-    RETURN_TYPES = ("FLOAT",)
-    FUNCTION = "calc_sigma"
-
-    CATEGORY = "latent/noise"
-        
-    def calc_sigma(self, model, sampler_name, scheduler, steps, start_at_step, end_at_step):
-        device = comfy.model_management.get_torch_device()
-        end_at_step = min(steps, end_at_step)
-        start_at_step = min(start_at_step, end_at_step)
-        sampler = comfy.samplers.KSampler(model, steps=steps, device=device, sampler=sampler_name, scheduler=scheduler, denoise=1.0, model_options=model.model_options)
-        sigmas = sampler.sigmas
-        sigma = sigmas[start_at_step] - sigmas[end_at_step]
-        sigma /= model.model.latent_format.scale_factor
-        return (sigma.cpu().numpy(),)
-
 class LoadElla:
     def __init__(self):
         self.device = comfy.model_management.text_encoder_device()
@@ -136,12 +108,10 @@ class ELLATextEncode:
 NODE_CLASS_MAPPINGS = {
     "LoadElla": LoadElla,
     "ELLATextEncode": ELLATextEncode,
-    "GetSigma": GetSigma
 }
 
 # A dictionary that contains the friendly/humanly readable titles for the nodes
 NODE_DISPLAY_NAME_MAPPINGS = {
     "LoadElla": "Load ELLA Model",
     "ELLATextEncode": "ELLA Text Encode (Prompt)",
-    "GetSigma": "Get Sigma (BNK)"
 }


### PR DESCRIPTION
I have been comparing the results from this implementation to the diffusers implementation, and it's not on par. In diffusers ELLA is applied on each timestep, with the actual timestep value. Applying single sigma value in comfy doesn't produce the same results.

Now I don't know if this is a proper way to do it in Comfy, but it is giving far better results:
![image](https://github.com/ExponentialML/ComfyUI_ELLA/assets/40791699/d6b4bfac-e21b-45e8-9824-f32e14b98c9b)
